### PR TITLE
Set default na.strings of read.PED.BGData to 0

### DIFF
--- a/R/BGData.R
+++ b/R/BGData.R
@@ -93,7 +93,7 @@ setMethod('initialize','BGData',function(.Object,geno,pheno,map){
 #' @export
 read.PED.BGData<-function(fileIn,header,dataType,distributed.by='columns',n=NULL,p=NULL,
                           folderOut=paste('BGData_',sub("\\.[[:alnum:]]+$","",basename(fileIn)),sep=''),
-                          returnData=TRUE,na.strings='NA',nColSkip=6,idCol=2,verbose=FALSE,nChunks=NULL,
+                          returnData=TRUE,na.strings=0,nColSkip=6,idCol=2,verbose=FALSE,nChunks=NULL,
                           dimorder=if(distributed.by=='rows') 2:1 else 1:2){
     
     if(file.exists(folderOut)){


### PR DESCRIPTION
The PLINK documentation states that "genotypes (column 7 onwards) should also be white-space delimited; they can be any character (e.g. 1,2,3,4 or A,C,G,T or anything else) **except 0 which is, by default, the missing genotype character**." Other defaults such as `nColSkip` and `idCol` also default to PED, so I think this one should, too.
