### PR TITLE
Fix dataType parsing: scan uses typeof internally

### DIFF
--- a/R/BGData.R
+++ b/R/BGData.R
@@ -71,8 +71,8 @@ setMethod('initialize','BGData',function(.Object,geno,pheno,map){
 #' 
 #' @param fileIn The path to the plaintext file.
 #' @param header If TRUE, the file contains a header.
-#' @param dataType The coding of genotypes. Use 'character' for A/C/G/T or 
-#'   'integer' for numeric coding.
+#' @param dataType The coding of genotypes. Use 'character()' for A/C/G/T or 
+#'   'integer()' for numeric coding.
 #' @param distributed.by If columns a column-distributed matrix 
 #'   (\code{\linkS4class{cmmMatrix}}) is created, if rows a row-distributed 
 #'   matrix (\code{\linkS4class{rmmMatrix}}).
@@ -99,14 +99,14 @@ read.PED.BGData<-function(fileIn,header,dataType,distributed.by='columns',n=NULL
     if(file.exists(folderOut)){
         stop(paste('Output folder',folderOut,'already exists. Please move it or pick a different one.'))
     }
-    if(!dataType%in%c('character','integer','numeric')){
-        stop('dataType must be either character, integer or numeric')
+    if(!typeof(dataType)%in%c('character','integer','numeric')){
+        stop('dataType must be either character(), integer() or numeric()')
     }
     if(!distributed.by%in%c('columns','rows')){
         stop('distributed.by must be either columns or rows')
     }
     
-    vMode<-ifelse(dataType%in%c('character','integer'),'byte','double')
+    vMode<-ifelse(typeof(dataType)%in%c('character','integer'),'byte','double')
     
     if(is.null(n)){
         # gzfile and readLines throw some warnings, but since it works, let's
@@ -173,7 +173,7 @@ read.PED.BGData<-function(fileIn,header,dataType,distributed.by='columns',n=NULL
     
     BGData<-new('BGData',geno=geno,pheno=pheno)
     
-    attr(BGData,'origFile')<-list(path=fileIn,dataType=dataType)
+    attr(BGData,'origFile')<-list(path=fileIn,dataType=typeof(dataType))
     attr(BGData,'dateCreated')<-date()
     
     save(BGData,file=paste(folderOut,'/BGData.RData',sep=''))

--- a/man/read.PED.BGData.Rd
+++ b/man/read.PED.BGData.Rd
@@ -16,8 +16,8 @@ read.PED.BGData(fileIn, header, dataType, distributed.by = "columns",
 
 \item{header}{If TRUE, the file contains a header.}
 
-\item{dataType}{The coding of genotypes. Use 'character' for A/C/G/T or
-'integer' for numeric coding.}
+\item{dataType}{The coding of genotypes. Use 'character()' for A/C/G/T or
+'integer()' for numeric coding.}
 
 \item{distributed.by}{If columns a column-distributed matrix
 (\code{\linkS4class{cmmMatrix}}) is created, if rows a row-distributed


### PR DESCRIPTION
I just noticed that the `what` parameter of the `scan` function uses `typeof` internally to derive the type, e.g. passing in the string `'integer'` will be considered `character`. We never noticed this behavior because `ff` then converts the character vectors to integers. We will have to re-evaluate if this has any performance benefits (I'm now surprised that we noticed speed-ups to begin with). In the meantime, this will serve as a quick fix to support returning matrices (that don't convert character vectors to integers).
